### PR TITLE
Find events based on their end date on the home page.

### DIFF
--- a/main_site/views.py
+++ b/main_site/views.py
@@ -25,7 +25,7 @@ class MainView(TemplateView):
         context['teams'] = Team.objects.order_by('name').all()
 
         # Show only the latest four, still visible events.
-        context['events'] = Event.objects.filter(visible=True, start__gte=datetime.datetime.now()).order_by('start')[:4].all()
+        context['events'] = Event.objects.filter(visible=True, end__gte=datetime.datetime.now()).order_by('start')[:4].all()
 
         # Show only the latest three news articles that are visible.
         context['news_articles'] = NewsArticle.objects.filter(visible=True).order_by('-date')[:3].all()


### PR DESCRIPTION
Events should be displayed till they have fully finished.